### PR TITLE
Static position for queue button

### DIFF
--- a/templates/season/inhouse
+++ b/templates/season/inhouse
@@ -7,11 +7,6 @@
   Current Queue
 </div>
 
-<div id="inhouseQueue">
-  Queue is currently empty.
-</div>
-<div id="inhouseConfig"></div>
-
 {?canQueueInhouses}
   <input type="button"
          id="queueMe"
@@ -25,6 +20,11 @@
 		 value="Leave Queue"
 		 onclick="ld2l.inhouseQueue.leaveQueue();" />
 {/canQueueInhouses}
+
+<div id="inhouseQueue">
+  Queue is currently empty.
+</div>
+<div id="inhouseConfig"></div>
 
 {>season_footer /}
 {>footer /}


### PR DESCRIPTION
Assuming your inhouseConfig div is the list of players, this would move the queue button above that so that the button doesn't move every time somebody queues up. Then again I didn't test it either, so take it or leave it I guess.